### PR TITLE
Not all HTTP methods supported

### DIFF
--- a/txfake/fake_connection.py
+++ b/txfake/fake_connection.py
@@ -280,13 +280,7 @@ class HandlerResource(Resource):
         Resource.__init__(self)
         self.handler = handler
 
-    def render_GET(self, request):
-        return self.handler(request)
-
-    def render_POST(self, request):
-        return self.handler(request)
-
-    def render_PUT(self, request):
+    def render(self, request):
         return self.handler(request)
 
 

--- a/txfake/tests/test_fake_connection.py
+++ b/txfake/tests/test_fake_connection.py
@@ -434,3 +434,35 @@ class TestFakeHttpServer(TestCase):
         self.assertEqual(request.method, "PUT")
         self.assertEqual(request.path, b"http://example.com/hello")
         yield self.assert_response(response, 200, b"hi")
+
+    @inlineCallbacks
+    def test_DELETE_request(self):
+        """
+        FakeHttpServer can handle a DELETE request.
+        """
+        requests = []
+        fake_http = FakeHttpServer(lambda req: requests.append(req) or b"hi")
+        agent = fake_http.get_agent()
+        self.assertTrue(IAgent.providedBy(agent))
+        response = yield agent.request("DELETE", b"http://example.com/hello")
+        # We got a valid request and returned a valid response.
+        [request] = requests
+        self.assertEqual(request.method, "DELETE")
+        self.assertEqual(request.path, b"http://example.com/hello")
+        yield self.assert_response(response, 200, b"hi")
+
+    @inlineCallbacks
+    def test_XMYSTERY_request(self):
+        """
+        FakeHttpServer can handle a request with an arbitrary verb.
+        """
+        requests = []
+        fake_http = FakeHttpServer(lambda req: requests.append(req) or b"hi")
+        agent = fake_http.get_agent()
+        self.assertTrue(IAgent.providedBy(agent))
+        response = yield agent.request("XMYSTERY", b"http://example.com/hello")
+        # We got a valid request and returned a valid response.
+        [request] = requests
+        self.assertEqual(request.method, "XMYSTERY")
+        self.assertEqual(request.path, b"http://example.com/hello")
+        yield self.assert_response(response, 200, b"hi")


### PR DESCRIPTION
There are currently only [request handlers](https://github.com/jerith/txfake/blob/0.1.0/txfake/fake_connection.py#L283-L290) for `GET`, `POST` and `PUT`. (Twisted also adds `HEAD` internally).

Other methods such as `DELETE` or `PATCH` are not supported.
